### PR TITLE
Fix event timestamps to show minutes

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -78,7 +78,7 @@ const EventsPage = async () => {
               {events.map((event) => {
                 const Icon = eventIcon(event.name);
                 const isMakersInn = makersInn(event.location ?? "");
-                const formattedDate = `${formatDate(event.start, "dd. MMM yyyy | HH")} Uhr`;
+                const formattedDate = `${formatDate(event.start, "dd. MMM yyyy | HH:mm")} Uhr`;
                 return (
                   <article key={event.id}>
                     <div className="mb-2 flex items-center gap-3">

--- a/components/EventsSection.tsx
+++ b/components/EventsSection.tsx
@@ -20,7 +20,7 @@ export const EventsSection = async () => {
       <ul className="mb-14 grid grid-cols-1 gap-16 lg:grid-cols-3 lg:gap-8">
         {nextEvents.map((event) => {
           const Icon = eventIcon(event.name);
-          const formattedDate = `${formatDate(event.start, "dd. MMM yyyy | HH")} Uhr`;
+          const formattedDate = `${formatDate(event.start, "dd. MMM yyyy | HH:mm")} Uhr`;
           return (
             <li key={event.id} className="flex flex-col justify-between">
               <div>


### PR DESCRIPTION
## Summary
- Fixed date format from `HH` to `HH:mm` so event times display correctly
- Events now show "12:30 Uhr" instead of just "12 Uhr"

## Test plan
- [x] Check events page displays correct times with minutes
- [x] Check events section on homepage displays correct times with minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)